### PR TITLE
Send original mimeobject

### DIFF
--- a/lib/RT/Action/SendBounce.pm
+++ b/lib/RT/Action/SendBounce.pm
@@ -71,7 +71,7 @@ sub Prepare {
 
     $self->{ForwardedTransactionObj} = $forwarded_txn;
 
-    my $entity = $self->ForwardedTransactionObj->ContentAsMIME;
+    my $entity = ContentSansFromAsMIME($self->ForwardedTransactionObj->Attachments->First, { Children => 1 });
 
     my $txn_attachment = $self->TransactionObj->Attachments->First;
     for my $header (qw/From To Cc Bcc/) {
@@ -87,6 +87,45 @@ sub Prepare {
     $self->TemplateObj->{MIMEObj} = $entity;
 
     $self->SUPER::Prepare();
+}
+
+# This is a copy of RT::Attachment::ContentAsMIME, which
+# copies all headers except the "From " and X-RT-* headers.
+sub ContentSansFromAsMIME {
+    my ($self) = shift;
+    my %opts = (
+        Children => 0,
+        @_
+    );
+
+    my $entity = MIME::Entity->new();
+    foreach my $header ($self->SplitHeaders) {
+        next if $header =~ m/^From / || $header =~ m/^X-RT-/;
+        my ($h_key, $h_val) = split /:/, $header, 2;
+        $entity->head->add(
+            $h_key, $self->_EncodeHeaderToMIME($h_key, $h_val)
+        );
+    }
+
+    if ($entity->is_multipart) {
+        if ($opts{'Children'} and not $self->IsMessageContentType) {
+            my $children = $self->Children;
+            while (my $child = $children->Next) {
+                $entity->add_part( $child->ContentAsMIME(%opts) );
+            }
+        }
+    } else {
+        # since we want to return original content, let's use original encoding
+        $entity->head->mime_attr(
+            "Content-Type.charset" => $self->OriginalEncoding )
+          if $self->OriginalEncoding;
+
+        $entity->bodyhandle(
+            MIME::Body::Scalar->new( $self->OriginalContent )
+        );
+    }
+
+    return $entity;
 }
 
 sub SetSubjectToken {


### PR DESCRIPTION
I've pondered this for a while. This commit is pushing the original entity back into the SMTP instead of using a template->Parse().

Not done yet:
- [ ] Full RFC bounce headers (RFC5322, section 3.6.6)
- [ ] reduction of X-RT-\* headers in outgoing mail

But the direction this is going is easier to see without those changes.
