### PR TITLE
Add informational headers

### DIFF
--- a/html/Ticket/Bounce.html
+++ b/html/Ticket/Bounce.html
@@ -115,8 +115,6 @@ my ( $status, $msg ) = Bounce($TicketObj, Transaction => $txn, %ARGS );
 
 my $Title = loc('Bounce transaction #[_1]', $txn->id);
 
-my $from = RT::Interface::Email::GetForwardFrom( Transaction => $txn );
-
 my $subject = $txn->Subject;
 
 my $Content = $txn->Content;
@@ -125,6 +123,8 @@ my $attachments = RT::Interface::Email::GetForwardAttachments(
     Ticket => $TicketObj,
     Transaction => $txn,
 );
+
+my $from = $attachments->First->GetHeader('From');
 
 # this should possibly somwhere else but wtf
 sub Bounce {


### PR DESCRIPTION
I'm setting an X-Original-To/Cc, as we can't change the
envelope without changing the headers, as RT::Action::SendEmail
just uses the To/Cc/Bcc from the headers as the envelope.

For the other headears I've tried to follow RFC5322, section 3.3.6.

TODO: removing all the X-RT-\* headers.
